### PR TITLE
Fix example factorial tool for smaller numbers.

### DIFF
--- a/examples/src/calculator_server.clj
+++ b/examples/src/calculator_server.clj
@@ -127,10 +127,11 @@
                  :text "Error: Factorial requires a non-negative integer",
                  :isError true}
                 ;; Simulate longer computation for large numbers
-                (when (> number 10)
-                  (Thread/sleep 1000)
-                  {:type "text",
-                   :text (str (reduce * (range 1 (inc number))))})))})
+                (do
+                 (when (> number 10)
+                   (Thread/sleep 1000))
+                 {:type "text",
+                  :text (str (reduce * (range 1 (inc number))))})))})
 
 (def calculator-server-spec
   {:name "calculator",


### PR DESCRIPTION
Small fix to avoid factorial hanging when numbers are <= 10.