### PR TITLE
fix: Prevent JSON serialization errors and accept keyword keys in tool properties

### DIFF
--- a/src/io/modelcontext/clojure_sdk/server.clj
+++ b/src/io/modelcontext/clojure_sdk/server.clj
@@ -309,10 +309,17 @@
 ;;; Server Spec
 
 (defn validate-spec!
+  "Validates the server-spec and throws if invalid.
+   Strips handler functions before logging to avoid JSON serialization errors."
   [server-spec]
   (when-not (specs/valid-server-spec? server-spec)
-    (let [msg "Invalid server-spec definition"]
-      (log/debug :msg msg :spec server-spec)
+    (let [msg "Invalid server-spec definition"
+          ;; Strip handlers before logging to avoid JSON serialization errors
+          loggable-spec (-> server-spec
+                            (update :tools (fn [tools] (mapv #(dissoc % :handler) tools)))
+                            (update :prompts (fn [prompts] (mapv #(dissoc % :handler) prompts)))
+                            (update :resources (fn [resources] (mapv #(dissoc % :handler) resources))))]
+      (log/debug :msg msg :spec loggable-spec)
       (throw (ex-info msg (specs/explain-server-spec server-spec)))))
   server-spec)
 

--- a/src/io/modelcontext/clojure_sdk/specs.clj
+++ b/src/io/modelcontext/clojure_sdk/specs.clj
@@ -529,7 +529,7 @@
 ;; Definition for a tool the client can call.
 (s/def :tool/name string?)
 (s/def :tool/description string?)
-(s/def :tool/properties (s/map-of string? any?))
+(s/def :tool/properties (s/map-of (s/or :str string? :kw keyword?) any?))
 (s/def :tool/required (s/coll-of string?))
 (s/def :schema/type #{"object"})
 ;; A JSON Schema object defining the expected parameters for the tool.


### PR DESCRIPTION
## Summary

This PR fixes two issues encountered when building an MCP server with the SDK.

## Context

While developing [emacs-mcp](https://github.com/BuddhiLW/emacs-mcp), an MCP server that integrates Claude Code with Emacs, we encountered a crash on server startup:

```
Execution error (JsonGenerationException) at cheshire.generate/generate (generate.clj:155).
Cannot JSON encode object of class: class emacs_mcp.tools$handle_eval_elisp
```

Investigating the stack trace led us to `validate-spec!`, which was trying to log the full `server-spec` (including handler functions) when validation failed. This revealed a second issue: the spec validation itself was failing because our tool definitions used keyword keys in `inputSchema.properties` (e.g., `:function_name`), but the spec only accepted string keys.

## Changes

### `server.clj`
- Modified `validate-spec!` to strip `:handler` keys from tools, prompts, and resources before logging
- Added docstring explaining the fix

### `specs.clj`  
- Changed `:tool/properties` spec from `(s/map-of string? any?)` to `(s/map-of (s/or :str string? :kw keyword?) any?)` to accept both string and keyword keys

## Test plan
- [x] MCP server starts without crashing when tools use keyword keys in inputSchema
- [x] Spec validation errors are properly logged without JSON serialization failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Pedro Branquinho <pedrogbranquinho@gmail.com>
Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>