### PR TITLE
fix(ci): format for zprint 1.3.0 and pass repo config explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 HOME := $(shell echo $$HOME)
 HERE := $(shell echo $$PWD)
+ZPRINT_CONFIG := $(shell cat $(HERE)/.zprint.edn)
 CLOJURE_SOURCES := $(shell find . -name '**.clj' -not -path './.clj-kondo/*' -not -path './vendors/*')
 
 # Set bash instead of sh for the @if [[ conditions,
@@ -144,13 +145,13 @@ check-cljkondo:
 	clj-kondo --lint .
 
 check-zprint:
-	zprint -c $(CLOJURE_SOURCES)
+	zprint '$(ZPRINT_CONFIG)' -c $(CLOJURE_SOURCES)
 
 check: check-tagref check-cljkondo check-zprint    ## Check that the code is well linted and well formatted
 	@echo "All checks passed!"
 
 format:   ## Format the code using zprint
-	zprint -lfw $(CLOJURE_SOURCES)
+	zprint '$(ZPRINT_CONFIG)' -lfw $(CLOJURE_SOURCES)
 
 test-coverage:
 	clojure -X:dev:test:clofidence

--- a/src/io/modelcontext/clojure_sdk/server.clj
+++ b/src/io/modelcontext/clojure_sdk/server.clj
@@ -314,11 +314,16 @@
   [server-spec]
   (when-not (specs/valid-server-spec? server-spec)
     (let [msg "Invalid server-spec definition"
-          ;; Strip handlers before logging to avoid JSON serialization errors
-          loggable-spec (-> server-spec
-                            (update :tools (fn [tools] (mapv #(dissoc % :handler) tools)))
-                            (update :prompts (fn [prompts] (mapv #(dissoc % :handler) prompts)))
-                            (update :resources (fn [resources] (mapv #(dissoc % :handler) resources))))]
+          ;; Strip handlers before logging to avoid JSON serialization
+          ;; errors
+          loggable-spec
+            (-> server-spec
+                (update :tools (fn [tools] (mapv #(dissoc % :handler) tools)))
+                (update :prompts
+                        (fn [prompts] (mapv #(dissoc % :handler) prompts)))
+                (update :resources
+                        (fn [resources]
+                          (mapv #(dissoc % :handler) resources))))]
       (log/debug :msg msg :spec loggable-spec)
       (throw (ex-info msg (specs/explain-server-spec server-spec)))))
   server-spec)

--- a/src/io/modelcontext/clojure_sdk/specs.clj
+++ b/src/io/modelcontext/clojure_sdk/specs.clj
@@ -529,7 +529,10 @@
 ;; Definition for a tool the client can call.
 (s/def :tool/name string?)
 (s/def :tool/description string?)
-(s/def :tool/properties (s/map-of (s/or :str string? :kw keyword?) any?))
+(s/def :tool/properties
+  (s/map-of (s/or :str string?
+                  :kw keyword?)
+            any?))
 (s/def :tool/required (s/coll-of string?))
 (s/def :schema/type #{"object"})
 ;; A JSON Schema object defining the expected parameters for the tool.


### PR DESCRIPTION
## Problem

CI installs zprint `latest` (now **1.3.0**), which reformats two long forms that an older zprint left on one line:

- `validate-spec!`'s `loggable-spec` binding + its comment (wrapped at 80 cols)
- the `:tool/properties` spec (`(s/map-of (s/or ...) any?)`)

So `make format` produces changes and the *Ensure formatting clean* gate fails. This also blocks **#5** (client-support), whose CI runs on the merge into `main` and inherits these unformatted lines.

## Fix

- Reformat those two forms to their zprint-1.3.0 canonical shape (whitespace only, no behavior change).
- Port the explicit `$(ZPRINT_CONFIG)` pass-through into the Makefile's `format`/`check-zprint` targets, so CI (which has no `~/.zprint.edn`) applies the repo's `:fn-map`/`:map` config deterministically instead of relying on home-config discovery.

Verified: `make check` and `make format` are clean and idempotent with an empty `HOME` (CI conditions); `make test` green (23 tests, 111 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)